### PR TITLE
Add UCPtools to UCP Validation & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Merchants wanting maximum reach may implement both.
 ### ✅ UCP Validation & Testing
 
 - [UCP Playground](https://ucp.dev/playground/) - Official testing environment
+- [UCPtools](https://ucptools.dev) - Free UCP validator and ACP readiness checker — validates UCP manifests and checks ACP (ChatGPT Instant Checkout) eligibility in one tool
 - [UCP Checker](https://ucpchecker.com/) - Schema compliance validation
 - [UCP Lighthouse](https://ucp.rest/) - Payload validation
 - [Merchant Directory](https://merchants.awesomeucp.com/) - UCP-enabled merchants


### PR DESCRIPTION
## Summary

- Added [UCPtools](https://ucptools.dev) to the **UCP Validation & Testing** section in Developer Tools
- UCPtools is a free tool that validates UCP manifests and checks ACP (ChatGPT Instant Checkout) readiness in one place

## What was added

```markdown
- [UCPtools](https://ucptools.dev) - Free UCP validator and ACP readiness checker — validates UCP manifests and checks ACP (ChatGPT Instant Checkout) eligibility in one tool
```

## Why this fits

UCPtools is the first developer tool to cover **both** AI commerce protocols:
- **UCP validation**: Profile validation, AI agent simulation, security scanning, conformance testing
- **ACP readiness**: Checks 5 categories (platform detection, Stripe integration, policy pages, HTTPS, checkout signals) with 0-100 scoring

This fits the existing "UCP Validation & Testing" section alongside UCP Playground, UCP Checker, and UCP Lighthouse. It also bridges UCP and ACP — relevant since this repo covers all agentic commerce protocols.

Website: https://ucptools.dev