### PR TITLE
Add Human Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Merchants wanting maximum reach may implement both.
 - [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) - Agent-to-tool communication standard
 - [MCP GitHub](https://github.com/modelcontextprotocol) - MCP repositories
 - [OAuth 2.0](https://oauth.net/2/) - Authorization framework used by UCP
+- [Human Pages](https://humanpages.ai) - The open directory AI agents use to hire humans for real-world tasks. x402 pay-per-use pricing in USDC on Base.
 
 <br>
 


### PR DESCRIPTION
Adds [Human Pages](https://humanpages.ai) — the open directory AI agents use to hire humans for real-world tasks. x402 pay-per-use pricing in USDC on Base.

- Website: https://humanpages.ai
- GitHub: https://github.com/human-pages-ai/humanpages