### PR TITLE
Add Agentprobe — 13-probe agentic commerce readiness scorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Cloudflare's Agents SDK embeds payment rails directly into the edge infrastructu
 - [UCP Checker](https://ucpchecker.com/) - Schema compliance validation
 - [UCP Lighthouse](https://ucp.rest/) - Payload validation
 - [Merchant Directory](https://merchants.awesomeucp.com/) - UCP-enabled merchants
+- [Agentprobe](https://agentprobe.fly.dev) - Agentic commerce readiness scorer: 13-probe test suite checks llms.txt, OpenAPI, commerce.json, catalog/quote/checkout APIs, payment rail declarations, fulfillment proof, and no-fake-claims verification. Free public API + MCP endpoint.
 
 ### 🤖 Agent Development
 


### PR DESCRIPTION
## What is Agentprobe?

[Agentprobe](https://agentprobe.fly.dev) is a free public tool that scores any seller URL across 13 agentic commerce readiness checks:

- llms.txt / OpenAPI / ai-plugin.json / MCP presence
- commerce.json with payment rail declaration
- Machine-readable catalog (`/api/v1/catalog`)
- Quote endpoint (`/api/v1/quote`)
- Checkout endpoint (`/api/v1/checkout`)
- Explicit payment rail declaration (UCP/ACP/Stripe)
- Refund/contact metadata
- Unsupported-rail declaration (x402/SPT/MPP correctly marked)
- No fake/unsubstantiated x402/SPT/MPP claims
- Fulfillment proof endpoint

## Why it fits this list

The "Developer Tools → UCP Validation & Testing" section already includes UCP Checker and UCP Lighthouse for schema/payload validation. Agentprobe covers the broader agentic commerce readiness surface — not just UCP schema compliance, but whether an AI agent can actually complete a purchase end-to-end.

## Live

- Probe any URL: https://agentprobe.fly.dev
- API: `GET /api/probe?url=<url>`
- MCP endpoint: `/mcp` (probe_site tool)
- Registry/leaderboard: https://agentprobe.fly.dev/registry
- Badge: `/badge/{domain}.svg`

Currently certifying 4 production seller sites at 100–110/110.