### PR TITLE
Add Packrift MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ Cloudflare's Agents SDK embeds payment rails directly into the edge infrastructu
 ## Tools & Plugins
 
 - [Agentic Commerce Claude Plugins](https://github.com/OrcaQubits/agentic-commerce-claude-plugins) - Claude Code plugins for agentic commerce protocol development (UCP, ACP, AP2, A2A)
+- [Packrift MCP](https://github.com/Packrift/packrift-mcp) - Packaging procurement MCP server for AI commerce agents to query exact-size SKUs, carton-fit recommendations, shipping estimates, and dimensional-weight options.
 
 <br>
 


### PR DESCRIPTION
Adds Packrift MCP to the Tools & Plugins section as a packaging procurement MCP server for agentic-commerce workflows.\n\nValidation:\n- Verified https://github.com/Packrift/packrift-mcp returns HTTP 200\n- Ran git diff --check