### PR TITLE
Add AgentServices — live x402 implementation (54 services, 37 MCP tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,9 @@ x402 leverages HTTP's `402 Payment Required` status code for instant stablecoin 
 - [Stellar x402 Facilitator](https://stellar.org/blog/foundation-news/x402-on-stellar) - Production facilitator on OpenZeppelin Relayer (sub-5s settlement)
 - [Pay.sh by Solana + Google Cloud](https://www.banklesstimes.com/articles/2026/05/06/solana-and-google-cloud-launch-pay-sh-for-ai-agent-micropayments/) - May 2026 stablecoin micropayment gateway for AI agents accessing Gemini, BigQuery, Vertex AI, and 50+ APIs
 
+**Live x402 Implementations:**
+- [AgentServices](https://agentservices.to) — Production x402-paid data API platform: 54 services, 37 MCP tools, 41 x402-paid endpoints (crypto prices, DeFi yields, market data, social analytics). On official MCP Registry, first x402 payment confirmed Jul 2026.
+
 ### L402
 
 > Macaroons + Lightning Network micropayments for stateless API authentication


### PR DESCRIPTION
## What

This PR adds **AgentServices** as a live x402 implementation under the Crypto Payment Rails → x402 section.

[AgentServices](https://agentservices.to) is a production x402-paid data API platform for AI agents:
- **54 services** across crypto prices, DeFi yields, market data, social analytics, news, and more
- **37 MCP tools** (listed on official MCP Registry as `to.agentservices/agentservices` v5.3.0)
- **41 x402-paid endpoints** settling in USDC on Base
- First x402 payment confirmed on Base mainnet (Jul 13, 2026)

## Why

This list documents the agentic commerce stack with protocols, specs, and tools. AgentServices is a live, production implementation of x402 — the kind of real-world deployment that demonstrates the protocol working at scale. Adding it under x402 helps readers see what x402 looks like in practice.

## Verification

- Live at [agentservices.to](https://agentservices.to)
- Health: v5.3.0, x402 enabled, 97 API paths
- MCP handshake verified (protocol 2026-07-28)
- Listed on [official MCP Registry](https://registry.modelcontextprotocol.io)
- On [Glama](https://glama.ai/mcp/servers/vbkotecha/aiservices-api)